### PR TITLE
Fix footer link to link to git hub

### DIFF
--- a/src/components/FooterLinks.js
+++ b/src/components/FooterLinks.js
@@ -36,7 +36,7 @@ const FooterLinks = () => (
       <Trans>Ready to use the Energuide API?</Trans>
       {'  '}
       <br />
-      <a href="https://bit.ly/2HxeqDm">
+      <a href="https://github.com/cds-snc/nrcan_api">
         <Trans>Get access</Trans>
       </a>
     </li>


### PR DESCRIPTION
Part one of addressing https://github.com/cds-snc/nrcan_api/issues/480 

Replace the link to the GraphiQL interface with a link to the nrcan_api repo