### PR TITLE
Ask for both ersRating and eghRating & display one

### DIFF
--- a/src/components/ResultsFileID.js
+++ b/src/components/ResultsFileID.js
@@ -41,21 +41,24 @@ function ShowFileID({ dwelling, fileId }) {
       JSON.stringify(returnTheRightEvaluation(dwelling.evaluations)),
     )
 
-    let { ersRating = {} } = evaluation
+    let { ersRating = {}, eghRating = {} } = evaluation
     let { greenhouseGasEmissions = {} } = evaluation
 
-    return {
+    let result = {
       City: dwelling.city,
       'Year built': dwelling.yearBuilt,
       'House type': evaluation.houseType,
       'Evaluation type': evaluation.evaluationType,
-      'ERS rating':
-        ersRating.measurement === null ? null : ersRating.measurement + ' GJ',
-      'Greenhouse Gas Emissions':
-        greenhouseGasEmissions.measurement === null
-          ? null
-          : greenhouseGasEmissions.measurement + ' ' + i18n.t`tonnes/year`,
+      'Energuide rating':
+        ersRating.measurement === null
+          ? eghRating.measurement + '/100'
+          : ersRating.measurement + ' GJ',
     }
+    if (greenhouseGasEmissions.measurement)
+      result['Greenhouse Gas Emissions'] = `${
+        greenhouseGasEmissions.measurement
+      } ${i18n.t`tonnes/year`}`
+    return result
   }
 
   return (

--- a/src/queries.js
+++ b/src/queries.js
@@ -1,7 +1,7 @@
 import gql from 'graphql-tag'
 
 export const getEvaluationByFileId = gql`
-  query getEvaluationByFileId($fileId: String!) {
+  query POCgetEvaluationByFileId($fileId: String!) {
     dwellings(
       filters: [{ field: evaluationFileId, comparator: eq, value: $fileId }]
     ) {
@@ -13,6 +13,9 @@ export const getEvaluationByFileId = gql`
           fileId
           houseType
           ersRating {
+            measurement
+          }
+          eghRating {
             measurement
           }
           greenhouseGasEmissions {


### PR DESCRIPTION
Now that most of the data has been added, the majority of it only has
the old 0/100 rating (aka eghRating) not the new gigajoule rating (aka
ersRating). This change data broke some of our assumptions about what was
going to be available so we ended up displaying nothing in the majority
of cases.