### PR TITLE
Fetch data everywhere

### DIFF
--- a/src/routesMap.js
+++ b/src/routesMap.js
@@ -11,15 +11,13 @@ export default {
   RESULTSFILEID: {
     path: '/results-fileid/:fileId',
     thunk: async (dispatch, getState) => {
-      if (typeof window === 'undefined') {
-        const { fileId } = getState().location.payload
-        let response = await client.query({
-          query: getEvaluationByFileId,
-          variables: { fileId },
-        })
-        if (response.data.dwellings.results.length > 0) {
-          dispatch(saveFileIdData(response.data.dwellings.results[0]))
-        }
+      const { fileId } = getState().location.payload
+      let response = await client.query({
+        query: getEvaluationByFileId,
+        variables: { fileId },
+      })
+      if (response.data.dwellings.results.length > 0) {
+        dispatch(saveFileIdData(response.data.dwellings.results[0]))
       }
     },
   },


### PR DESCRIPTION
Previously data was only fetched if the code was executing on the
server. Since the Apollo code is isomorphic we can remove the check and
execute it all the time.