### PR TITLE
Always return an object

### DIFF
--- a/src/components/ResultsFileID.js
+++ b/src/components/ResultsFileID.js
@@ -32,7 +32,7 @@ const isEmpty = obj =>
 
 function ShowFileID({ dwelling, fileId }) {
   const returnTheRightEvaluation = evaluations => {
-    return evaluations.find(e => e.fileId === fileId)
+    return evaluations.find(e => e.fileId === fileId) || {}
   }
 
   const displayValues = dwelling => {
@@ -109,7 +109,6 @@ const ResultsFileID = props => (
       </NavLink>
       <Trans>Results</Trans>
     </Breadcrumbs>
-
     {!isEmpty(props.data) && (
       <ShowFileID dwelling={props.data} fileId={props.fileId} />
     )}


### PR DESCRIPTION
The code that uses `returnTheRightEvaluation` assumes an object is
returned. It turns out that isn't a safe assumption.