### PR TITLE
Show NoResults only after fetch

### DIFF
--- a/src/__tests__/dataFetching.test.js
+++ b/src/__tests__/dataFetching.test.js
@@ -1,0 +1,54 @@
+import { getDataForFileId } from '../dataFetching'
+
+describe('Data fetching functions', () => {
+  describe('getDataForFileId', () => {
+    it('returns a redux action with data', async () => {
+      let client = {
+        query: jest.fn(opts => ({
+          data: { dwellings: { results: [{ foo: 'bar' }] } },
+        })),
+      }
+      const action = await getDataForFileId('1234asdf', client)
+      expect(action).toEqual({
+        data: { foo: 'bar' },
+        type: 'SAVE_FILEID_LOOKUP_RESULTS',
+      })
+    })
+
+    it('returns an empty object when there are no results', async () => {
+      let client = {
+        query: jest.fn(opts => ({
+          data: { dwellings: { results: [] } },
+        })),
+      }
+      const action = await getDataForFileId('1234asdf', client)
+      expect(action).toEqual({
+        data: {},
+        type: 'SAVE_FILEID_LOOKUP_RESULTS',
+      })
+    })
+
+    it('handles an errors array returned by the graphql endpoint', async () => {
+      let client = {
+        query: jest.fn(opts => ({
+          errors: [
+            {
+              locations: [
+                {
+                  column: 32,
+                  line: 5,
+                },
+              ],
+              message: 'your request is bad and you should feel bad',
+            },
+          ],
+        })),
+      }
+      let action = await getDataForFileId('1234asdf', client)
+      expect(action).toEqual({
+        data: {},
+        type: 'SAVE_FILEID_LOOKUP_RESULTS',
+      })
+    })
+  })
+})

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,5 +1,7 @@
 export const SET_LANGUAGE = 'SET_LANGUAGE'
 
+export const FETCHING = 'FETCHING'
+
 export const setLanguage = lang => ({
   type: SET_LANGUAGE,
   lang,
@@ -55,3 +57,7 @@ export const setFlash = (message = null, priority = null) => ({
   message,
   priority,
 })
+
+export const dataFetchingInProgress = () => ({ fetching: true, type: FETCHING })
+
+export const dataFetchingComplete = () => ({ fetching: false, type: FETCHING })

--- a/src/components/ResultsFileID.js
+++ b/src/components/ResultsFileID.js
@@ -9,7 +9,7 @@ import { NoResults } from './NoResults'
 import { Dwelling } from './Dwelling'
 import { isEmpty, displayValues } from '../utils'
 
-const ResultsFileID = props => (
+const ResultsFileID = ({ data, fetching, fileId }) => (
   <main role="main">
     <Breadcrumbs>
       <NavLink to="/">
@@ -25,14 +25,11 @@ const ResultsFileID = props => (
       </NavLink>
       <Trans>Results</Trans>
     </Breadcrumbs>
-    {!isEmpty(props.data) && (
-      <Dwelling
-        dwelling={displayValues(props.data, props.fileId)}
-        fileId={props.fileId}
-      />
+    {!isEmpty(data) && (
+      <Dwelling dwelling={displayValues(data, fileId)} fileId={fileId} />
     )}
 
-    {isEmpty(props.data) && <NoResults fileId={props.fileId} />}
+    {fetching === false && isEmpty(data) && <NoResults fileId={fileId} />}
     <FooterLinks />
   </main>
 )
@@ -40,10 +37,12 @@ const ResultsFileID = props => (
 ResultsFileID.propTypes = {
   data: PropTypes.object,
   fileId: PropTypes.string.isRequired,
+  fetching: PropTypes.bool.isRequired,
 }
 
 const mapStateToProps = state => ({
   path: state.location.pathname,
+  fetching: state.data.fetching,
   data: state.data.searchFileIdData,
   fileId: state.location.payload.fileId,
 })

--- a/src/dataFetching.js
+++ b/src/dataFetching.js
@@ -1,0 +1,14 @@
+import { saveFileIdData } from '../src/actions'
+import { getEvaluationByFileId } from '../src/queries'
+
+export const getDataForFileId = async (fileId, client) => {
+  let response = await client.query({
+    query: getEvaluationByFileId,
+    variables: { fileId },
+  })
+  if (response.data && response.data.dwellings.results.length > 0) {
+    return saveFileIdData(response.data.dwellings.results[0])
+  } else {
+    return saveFileIdData({})
+  }
+}

--- a/src/reducers/data.js
+++ b/src/reducers/data.js
@@ -1,13 +1,16 @@
 import {
+  FETCHING,
   SAVE_FILEID_LOOKUP_RESULTS,
   SAVE_LOCATION_LOOKUP_RESULTS,
 } from '../actions'
 
 export default (
-  state = { searchLocationData: [], searchFileIdData: {} },
+  state = { fetching: false, searchLocationData: [], searchFileIdData: {} },
   action = {},
 ) => {
   switch (action.type) {
+    case FETCHING:
+      return Object.assign({}, state, { fetching: action.fetching })
     case SAVE_LOCATION_LOOKUP_RESULTS:
       return Object.assign({}, state, { searchLocationData: action.data })
     case SAVE_FILEID_LOOKUP_RESULTS:

--- a/src/routesMap.js
+++ b/src/routesMap.js
@@ -1,6 +1,6 @@
+import { getDataForFileId } from '../src/dataFetching'
 import { client } from '../src/ApolloClient'
-import { saveFileIdData } from '../src/actions'
-import { getEvaluationByFileId } from '../src/queries'
+import { dataFetchingInProgress, dataFetchingComplete } from '../src/actions'
 
 export default {
   HOME: '/',
@@ -12,13 +12,10 @@ export default {
     path: '/results-fileid/:fileId',
     thunk: async (dispatch, getState) => {
       const { fileId } = getState().location.payload
-      let response = await client.query({
-        query: getEvaluationByFileId,
-        variables: { fileId },
-      })
-      if (response.data.dwellings.results.length > 0) {
-        dispatch(saveFileIdData(response.data.dwellings.results[0]))
-      }
+      dispatch(dataFetchingInProgress())
+      let action = await getDataForFileId(fileId, client)
+      dispatch(action)
+      dispatch(dataFetchingComplete())
     },
   },
 }


### PR DESCRIPTION
Previously the NoResults component was being displayed in the interval
between the beginning of the data fetching and the arrival of the actual
data. This made for a pretty confusing user experience.