### PR TITLE
Make sure webpack builds for prod

### DIFF
--- a/webpack/client.prod.js
+++ b/webpack/client.prod.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/unambiguous
 const path = require('path')
 const webpack = require('webpack')
 const ExtractCssChunks = require('extract-css-chunks-webpack-plugin')
@@ -81,10 +82,33 @@ module.exports = {
           'transition-group',
           'redux-first-router',
           'redux-first-router-link',
+          'fetch-everywhere',
           'babel-polyfill',
           'redux-devtools-extension/logOnlyInProduction',
         ],
       },
+      plugins: [
+        new webpack.DefinePlugin({
+          'process.env': {
+            NODE_ENV: JSON.stringify('production'),
+          },
+        }),
+
+        new webpack.optimize.UglifyJsPlugin({
+          compress: {
+            screw_ie8: true,
+            warnings: false,
+          },
+          mangle: {
+            screw_ie8: true,
+          },
+          output: {
+            screw_ie8: true,
+            comments: false,
+          },
+          sourceMap: true,
+        }),
+      ],
     }),
   ],
 }

--- a/webpack/server.prod.js
+++ b/webpack/server.prod.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/unambiguous
 const fs = require('fs')
 const path = require('path')
 const webpack = require('webpack')
@@ -8,15 +9,18 @@ const res = p => path.resolve(__dirname, p)
 // to still bundle `react-universal-component`, `webpack-flush-chunks` and
 // `require-universal-module` so that they know they are running
 // within Webpack and can properly make connections to client modules:
+
+// eslint-disable-next-line security/detect-non-literal-fs-filename
 const externals = fs
   .readdirSync(res('../node_modules'))
   .filter(
     x =>
       !/\.bin|react-universal-component|require-universal-module|webpack-flush-chunks/.test(
-        x
-      )
+        x,
+      ),
   )
   .reduce((externals, mod) => {
+    // eslint-disable-next-line security/detect-object-injection
     externals[mod] = `commonjs ${mod}`
     return externals
   }, {})
@@ -31,6 +35,7 @@ module.exports = {
     path: res('../buildServer'),
     filename: '[name].js',
     libraryTarget: 'commonjs2',
+    publicPath: '/static/',
   },
   module: {
     rules: [


### PR DESCRIPTION
Before the build wasn't producing a proper "compiled for production"
build, leaving us running the development version of React all the time.
This commit fixes that.