### PR TITLE
Fix result count display

### DIFF
--- a/src/components/ResultsLocation.js
+++ b/src/components/ResultsLocation.js
@@ -39,7 +39,8 @@ class ResultsLocation extends Component {
     if (!fetching) {
       return (
         <Header1>
-          <Trans>{data.length} results</Trans>
+          {data.length}
+          <Trans> results</Trans>
         </Header1>
       )
     }

--- a/src/components/locale/_build/src/components/ResultsLocation.json
+++ b/src/components/locale/_build/src/components/ResultsLocation.json
@@ -1,41 +1,9 @@
 {
-  "EnerGuide API": {
+  "results": {
     "origin": [
       [
         "src/components/ResultsLocation.js",
-        50
-      ]
-    ]
-  },
-  "Search": {
-    "origin": [
-      [
-        "src/components/ResultsLocation.js",
-        53
-      ]
-    ]
-  },
-  "Search by location": {
-    "origin": [
-      [
-        "src/components/ResultsLocation.js",
-        56
-      ]
-    ]
-  },
-  "Results": {
-    "origin": [
-      [
-        "src/components/ResultsLocation.js",
-        58
-      ]
-    ]
-  },
-  "{0} results": {
-    "origin": [
-      [
-        "src/components/ResultsLocation.js",
-        63
+        42
       ]
     ]
   },
@@ -43,7 +11,39 @@
     "origin": [
       [
         "src/components/ResultsLocation.js",
-        76
+        66
+      ]
+    ]
+  },
+  "EnerGuide API": {
+    "origin": [
+      [
+        "src/components/ResultsLocation.js",
+        78
+      ]
+    ]
+  },
+  "Search": {
+    "origin": [
+      [
+        "src/components/ResultsLocation.js",
+        81
+      ]
+    ]
+  },
+  "Search by location": {
+    "origin": [
+      [
+        "src/components/ResultsLocation.js",
+        84
+      ]
+    ]
+  },
+  "Results": {
+    "origin": [
+      [
+        "src/components/ResultsLocation.js",
+        86
       ]
     ]
   }

--- a/src/components/locale/en/messages.json
+++ b/src/components/locale/en/messages.json
@@ -1,22 +1,4 @@
 {
-  "{0} results": {
-    "translation": "",
-    "origin": [
-      [
-        "src/components/ResultsLocation.js",
-        63
-      ]
-    ]
-  },
-  "Search for another location": {
-    "translation": "",
-    "origin": [
-      [
-        "src/components/ResultsLocation.js",
-        76
-      ]
-    ]
-  },
   "Alpha": {
     "translation": "",
     "origin": [
@@ -114,7 +96,7 @@
       ],
       [
         "src/components/ResultsLocation.js",
-        50
+        78
       ],
       [
         "src/components/Search.js",
@@ -287,7 +269,7 @@
       ],
       [
         "src/components/ResultsLocation.js",
-        53
+        81
       ],
       [
         "src/components/Search.js",
@@ -324,7 +306,7 @@
       ],
       [
         "src/components/ResultsLocation.js",
-        56
+        84
       ],
       [
         "src/components/SearchLocation.js",
@@ -353,7 +335,7 @@
       ],
       [
         "src/components/ResultsLocation.js",
-        58
+        86
       ]
     ]
   },
@@ -398,6 +380,24 @@
       [
         "src/components/SearchFileID.js",
         55
+      ]
+    ]
+  },
+  "results": {
+    "translation": "",
+    "origin": [
+      [
+        "src/components/ResultsLocation.js",
+        42
+      ]
+    ]
+  },
+  "Search for another location": {
+    "translation": "",
+    "origin": [
+      [
+        "src/components/ResultsLocation.js",
+        66
       ]
     ]
   },
@@ -582,12 +582,12 @@
       ]
     ]
   },
-  "results": {
+  "{0} results": {
     "translation": "",
     "origin": [
       [
         "src/components/ResultsLocation.js",
-        58
+        63
       ]
     ],
     "obsolete": true

--- a/src/components/locale/fr/messages.json
+++ b/src/components/locale/fr/messages.json
@@ -1,22 +1,4 @@
 {
-  "{0} results": {
-    "translation": "{0} résultats",
-    "origin": [
-      [
-        "src/components/ResultsLocation.js",
-        63
-      ]
-    ]
-  },
-  "Search for another location": {
-    "translation": "",
-    "origin": [
-      [
-        "src/components/ResultsLocation.js",
-        76
-      ]
-    ]
-  },
   "Alpha": {
     "translation": "Alpha",
     "origin": [
@@ -114,7 +96,7 @@
       ],
       [
         "src/components/ResultsLocation.js",
-        50
+        78
       ],
       [
         "src/components/Search.js",
@@ -287,7 +269,7 @@
       ],
       [
         "src/components/ResultsLocation.js",
-        53
+        81
       ],
       [
         "src/components/Search.js",
@@ -324,7 +306,7 @@
       ],
       [
         "src/components/ResultsLocation.js",
-        56
+        84
       ],
       [
         "src/components/SearchLocation.js",
@@ -353,7 +335,7 @@
       ],
       [
         "src/components/ResultsLocation.js",
-        58
+        86
       ]
     ]
   },
@@ -398,6 +380,24 @@
       [
         "src/components/SearchFileID.js",
         55
+      ]
+    ]
+  },
+  "results": {
+    "translation": "résultats",
+    "origin": [
+      [
+        "src/components/ResultsLocation.js",
+        42
+      ]
+    ]
+  },
+  "Search for another location": {
+    "translation": "Recherche d'un autre lieu",
+    "origin": [
+      [
+        "src/components/ResultsLocation.js",
+        66
       ]
     ]
   },
@@ -582,12 +582,12 @@
       ]
     ]
   },
-  "results": {
-    "translation": "résultats",
+  "{0} results": {
+    "translation": "{0} résultats",
     "origin": [
       [
         "src/components/ResultsLocation.js",
-        58
+        63
       ]
     ],
     "obsolete": true


### PR DESCRIPTION
This was due to a known limitation of Lingui in displaying interpolated values.
I guess we never ran into this before.
Display was `{0} results` instead of the actual count